### PR TITLE
Refactor image loading logic into service

### DIFF
--- a/PicViewEx/ImageLoader.cs
+++ b/PicViewEx/ImageLoader.cs
@@ -1,0 +1,282 @@
+using ImageMagick;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace PicViewEx
+{
+    /// <summary>
+    /// 集中管理图片及相关资源的加载逻辑，便于在不同场景复用。
+    /// </summary>
+    public class ImageLoader
+    {
+        private readonly double backgroundOpacity;
+
+        public ImageLoader(double backgroundOpacity = 0.3)
+        {
+            this.backgroundOpacity = backgroundOpacity;
+        }
+
+        /// <summary>
+        /// 加载常规图片资源，优先使用 ImageMagick 以获得更好的格式兼容性。
+        /// </summary>
+        public BitmapImage LoadImage(string imagePath)
+        {
+            if (string.IsNullOrWhiteSpace(imagePath))
+                throw new ArgumentException("imagePath 不能为空", nameof(imagePath));
+
+            try
+            {
+                using (var magickImage = new MagickImage(imagePath))
+                {
+                    return CreateBitmapFromMagickImage(magickImage);
+                }
+            }
+            catch
+            {
+                try
+                {
+                    return LoadBitmapImageFromFile(imagePath);
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException($"无法加载图片: {imagePath}", ex);
+                }
+            }
+        }
+
+        /// <summary>
+        /// 为 GIF 动画加载静态源图像（用于 WpfAnimatedGif 控件）。
+        /// </summary>
+        public BitmapImage LoadGifAnimationSource(string gifPath)
+        {
+            if (string.IsNullOrWhiteSpace(gifPath))
+                throw new ArgumentException("gifPath 不能为空", nameof(gifPath));
+
+            var image = new BitmapImage();
+            image.BeginInit();
+            image.UriSource = new Uri(gifPath);
+            image.CacheOption = BitmapCacheOption.OnLoad;
+            image.EndInit();
+            image.Freeze();
+            return image;
+        }
+
+        /// <summary>
+        /// 从文件加载背景图片，并返回包含图像刷的结果。
+        /// </summary>
+        public BackgroundImageResult LoadBackgroundImage(string imagePath)
+        {
+            if (string.IsNullOrWhiteSpace(imagePath))
+                throw new ArgumentException("imagePath 不能为空", nameof(imagePath));
+            if (!File.Exists(imagePath))
+                throw new FileNotFoundException("背景图片不存在", imagePath);
+
+            var bitmap = LoadBitmapImageFromFile(imagePath);
+            var brush = CreateBackgroundBrush(bitmap);
+            return new BackgroundImageResult(brush, imagePath, usedFallback: false);
+        }
+
+        /// <summary>
+        /// 加载默认背景图片，如果默认资源不存在则回退到渐变背景。
+        /// </summary>
+        public BackgroundImageResult LoadDefaultBackgroundImage(string baseDirectory)
+        {
+            if (string.IsNullOrWhiteSpace(baseDirectory))
+                throw new ArgumentException("baseDirectory 不能为空", nameof(baseDirectory));
+
+            string defaultImagePath = Path.Combine(baseDirectory, "res", "01.jpg");
+            if (File.Exists(defaultImagePath))
+            {
+                var bitmap = LoadBitmapImageFromFile(defaultImagePath);
+                var brush = CreateBackgroundBrush(bitmap);
+                return new BackgroundImageResult(brush, defaultImagePath, usedFallback: false);
+            }
+
+            var fallbackBrush = CreateBackgroundBrush(CreateGradientImage());
+            return new BackgroundImageResult(fallbackBrush, null, usedFallback: true);
+        }
+
+        /// <summary>
+        /// 为指定图片生成 RGB/Alpha 通道。
+        /// </summary>
+        public List<Tuple<string, BitmapImage>> LoadChannels(string imagePath)
+        {
+            if (string.IsNullOrWhiteSpace(imagePath))
+                throw new ArgumentException("imagePath 不能为空", nameof(imagePath));
+
+            using (var magickImage = new MagickImage(imagePath))
+            {
+                return LoadChannelsFromMagickImage(magickImage);
+            }
+        }
+
+        /// <summary>
+        /// 为剪贴板图片生成通道信息。
+        /// </summary>
+        public List<Tuple<string, BitmapImage>> LoadChannels(BitmapSource source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            byte[] imageBytes = ConvertBitmapSourceToBytes(source);
+            using (var magickImage = new MagickImage(imageBytes))
+            {
+                return LoadChannelsFromMagickImage(magickImage);
+            }
+        }
+
+        private List<Tuple<string, BitmapImage>> LoadChannelsFromMagickImage(MagickImage magickImage)
+        {
+            var channels = new List<Tuple<string, BitmapImage>>();
+
+            var redImage = new MagickImage(magickImage);
+            try
+            {
+                redImage.Evaluate(Channels.Green, EvaluateOperator.Set, 0);
+                redImage.Evaluate(Channels.Blue, EvaluateOperator.Set, 0);
+                var redBitmap = CreateBitmapFromMagickImage(redImage);
+                channels.Add(Tuple.Create("红色 (R)", redBitmap));
+            }
+            finally
+            {
+                redImage.Dispose();
+            }
+
+            var greenImage = new MagickImage(magickImage);
+            try
+            {
+                greenImage.Evaluate(Channels.Red, EvaluateOperator.Set, 0);
+                greenImage.Evaluate(Channels.Blue, EvaluateOperator.Set, 0);
+                var greenBitmap = CreateBitmapFromMagickImage(greenImage);
+                channels.Add(Tuple.Create("绿色 (G)", greenBitmap));
+            }
+            finally
+            {
+                greenImage.Dispose();
+            }
+
+            var blueImage = new MagickImage(magickImage);
+            try
+            {
+                blueImage.Evaluate(Channels.Red, EvaluateOperator.Set, 0);
+                blueImage.Evaluate(Channels.Green, EvaluateOperator.Set, 0);
+                var blueBitmap = CreateBitmapFromMagickImage(blueImage);
+                channels.Add(Tuple.Create("蓝色 (B)", blueBitmap));
+            }
+            finally
+            {
+                blueImage.Dispose();
+            }
+
+            if (magickImage.HasAlpha)
+            {
+                var alphaImage = new MagickImage(magickImage);
+                try
+                {
+                    alphaImage.Alpha(AlphaOption.Extract);
+                    alphaImage.Format = MagickFormat.Png;
+                    var alphaBitmap = CreateBitmapFromMagickImage(alphaImage);
+                    channels.Add(Tuple.Create("透明 (Alpha)", alphaBitmap));
+                }
+                finally
+                {
+                    alphaImage.Dispose();
+                }
+            }
+
+            int expectedChannels = magickImage.HasAlpha ? 4 : 3;
+            if (channels.Count != expectedChannels)
+            {
+                throw new InvalidOperationException($"通道生成不完整，预期 {expectedChannels} 个通道，实际生成 {channels.Count} 个");
+            }
+
+            return channels;
+        }
+
+        private BitmapImage LoadBitmapImageFromFile(string imagePath)
+        {
+            var bitmap = new BitmapImage();
+            bitmap.BeginInit();
+            bitmap.UriSource = new Uri(imagePath);
+            bitmap.CacheOption = BitmapCacheOption.OnLoad;
+            bitmap.EndInit();
+            bitmap.Freeze();
+            return bitmap;
+        }
+
+        private ImageBrush CreateBackgroundBrush(BitmapSource source)
+        {
+            return new ImageBrush(source)
+            {
+                Stretch = Stretch.UniformToFill,
+                TileMode = TileMode.Tile,
+                Opacity = backgroundOpacity
+            };
+        }
+
+        private BitmapSource CreateGradientImage()
+        {
+            var visual = new DrawingVisual();
+            using (var context = visual.RenderOpen())
+            {
+                var gradientBrush = new LinearGradientBrush();
+                gradientBrush.StartPoint = new Point(0, 0);
+                gradientBrush.EndPoint = new Point(1, 1);
+                gradientBrush.GradientStops.Add(new GradientStop(Colors.LightBlue, 0.0));
+                gradientBrush.GradientStops.Add(new GradientStop(Colors.LightGray, 1.0));
+
+                context.DrawRectangle(gradientBrush, null, new Rect(0, 0, 256, 256));
+            }
+
+            var renderBitmap = new RenderTargetBitmap(256, 256, 96, 96, PixelFormats.Pbgra32);
+            renderBitmap.Render(visual);
+            renderBitmap.Freeze();
+            return renderBitmap;
+        }
+
+        private BitmapImage CreateBitmapFromMagickImage(MagickImage magickImage)
+        {
+            magickImage.Format = MagickFormat.Png;
+            byte[] imageBytes = magickImage.ToByteArray();
+
+            BitmapImage bitmap = new BitmapImage();
+            bitmap.BeginInit();
+            bitmap.StreamSource = new MemoryStream(imageBytes);
+            bitmap.CacheOption = BitmapCacheOption.OnLoad;
+            bitmap.EndInit();
+            bitmap.Freeze();
+
+            return bitmap;
+        }
+
+        private byte[] ConvertBitmapSourceToBytes(BitmapSource bitmapSource)
+        {
+            var encoder = new PngBitmapEncoder();
+            encoder.Frames.Add(BitmapFrame.Create(bitmapSource));
+
+            using (var ms = new MemoryStream())
+            {
+                encoder.Save(ms);
+                return ms.ToArray();
+            }
+        }
+    }
+
+    public class BackgroundImageResult
+    {
+        public BackgroundImageResult(ImageBrush brush, string sourcePath, bool usedFallback)
+        {
+            Brush = brush ?? throw new ArgumentNullException(nameof(brush));
+            SourcePath = sourcePath;
+            UsedFallback = usedFallback;
+        }
+
+        public ImageBrush Brush { get; }
+        public string SourcePath { get; }
+        public bool UsedFallback { get; }
+    }
+}

--- a/PicViewEx/MainWindow.xaml.cs
+++ b/PicViewEx/MainWindow.xaml.cs
@@ -42,6 +42,7 @@ namespace PicViewEx
         private SolidColorBrush currentBackgroundBrush = new SolidColorBrush(Colors.Gray); // 默认中性灰
         private ImageBrush backgroundImageBrush;
         private EverythingSearch everythingSearch;
+        private readonly ImageLoader imageLoader;
 
         // 拖拽相关
         private bool isDragging = false;
@@ -71,6 +72,8 @@ namespace PicViewEx
         public MainWindow()
         {
             InitializeComponent();
+
+            imageLoader = new ImageLoader();
 
             // 加载设置
             LoadAppSettings();
@@ -779,84 +782,67 @@ namespace PicViewEx
             // 如果切换到图片背景，但还没有设置背景图片，则加载默认图片
             if (rbImageBackground?.IsChecked == true && backgroundImageBrush == null)
             {
-                LoadDefaultBackgroundImage();
+                ApplyDefaultBackgroundImage(updateBackground: false, updateStatus: true);
             }
+
             UpdateBackground();
         }
 
-        private void LoadDefaultBackgroundImage()
+        private void ApplyDefaultBackgroundImage(bool updateBackground = true, bool updateStatus = true)
         {
             try
             {
-                // 获取exe所在目录
-                string exeDirectory = AppDomain.CurrentDomain.BaseDirectory;
-                string defaultImagePath = Path.Combine(exeDirectory, "res", "01.jpg");
+                var result = imageLoader.LoadDefaultBackgroundImage(AppDomain.CurrentDomain.BaseDirectory);
+                backgroundImageBrush = result.Brush;
 
-                if (File.Exists(defaultImagePath))
+                if (updateBackground)
+                    UpdateBackground();
+
+                if (updateStatus && statusText != null)
                 {
-                    BitmapImage bgImage = new BitmapImage();
-                    bgImage.BeginInit();
-                    bgImage.UriSource = new Uri(defaultImagePath);
-                    bgImage.CacheOption = BitmapCacheOption.OnLoad;
-                    bgImage.EndInit();
-                    bgImage.Freeze();
-
-                    backgroundImageBrush = new ImageBrush(bgImage)
+                    if (result.UsedFallback)
                     {
-                        Stretch = Stretch.UniformToFill,
-                        TileMode = TileMode.Tile,
-                        Opacity = 0.3
-                    };
-
-                    if (statusText != null)
-                        statusText.Text = "已加载默认背景图片: 01.jpg";
-                }
-                else
-                {
-                    // 如果默认图片不存在，创建一个简单的渐变背景
-                    var gradientBrush = new LinearGradientBrush();
-                    gradientBrush.StartPoint = new Point(0, 0);
-                    gradientBrush.EndPoint = new Point(1, 1);
-                    gradientBrush.GradientStops.Add(new GradientStop(Colors.LightBlue, 0.0));
-                    gradientBrush.GradientStops.Add(new GradientStop(Colors.LightGray, 1.0));
-
-                    backgroundImageBrush = new ImageBrush
-                    {
-                        ImageSource = CreateGradientImage(),
-                        Stretch = Stretch.UniformToFill,
-                        TileMode = TileMode.Tile,
-                        Opacity = 0.3
-                    };
-
-                    if (statusText != null)
                         statusText.Text = "默认图片不存在，使用渐变背景";
+                    }
+                    else if (!string.IsNullOrEmpty(result.SourcePath))
+                    {
+                        statusText.Text = $"已加载默认背景图片: {Path.GetFileName(result.SourcePath)}";
+                    }
                 }
             }
             catch (Exception ex)
             {
-                if (statusText != null)
+                if (updateStatus && statusText != null)
                     statusText.Text = $"加载默认背景图片失败: {ex.Message}";
             }
         }
 
-        private BitmapSource CreateGradientImage()
+        private bool ApplyBackgroundImageFromPath(string imagePath, bool updateStatus = false, bool updateBackground = true, bool setRadioButton = false)
         {
-            // 创建一个简单的渐变图像作为后备
-            var visual = new DrawingVisual();
-            using (var context = visual.RenderOpen())
+            try
             {
-                var gradientBrush = new LinearGradientBrush();
-                gradientBrush.StartPoint = new Point(0, 0);
-                gradientBrush.EndPoint = new Point(1, 1);
-                gradientBrush.GradientStops.Add(new GradientStop(Colors.LightBlue, 0.0));
-                gradientBrush.GradientStops.Add(new GradientStop(Colors.LightGray, 1.0));
+                var result = imageLoader.LoadBackgroundImage(imagePath);
+                backgroundImageBrush = result.Brush;
 
-                context.DrawRectangle(gradientBrush, null, new Rect(0, 0, 256, 256));
+                if (setRadioButton && rbImageBackground != null)
+                    rbImageBackground.IsChecked = true;
+
+                if (updateBackground)
+                    UpdateBackground();
+
+                if (updateStatus && statusText != null && !string.IsNullOrEmpty(result.SourcePath))
+                {
+                    statusText.Text = $"背景图片已设置: {Path.GetFileName(result.SourcePath)}";
+                }
+
+                return true;
             }
-
-            var renderBitmap = new RenderTargetBitmap(256, 256, 96, 96, PixelFormats.Pbgra32);
-            renderBitmap.Render(visual);
-            return renderBitmap;
+            catch (Exception ex)
+            {
+                if (updateStatus && statusText != null)
+                    statusText.Text = $"加载背景图片失败: {ex.Message}";
+                return false;
+            }
         }
 
         private void PresetColor_Click(object sender, RoutedEventArgs e)
@@ -1045,42 +1031,12 @@ namespace PicViewEx
 
             if (dialog.ShowDialog() == true)
             {
-                try
+                bool success = ApplyBackgroundImageFromPath(dialog.FileName, updateStatus: true, updateBackground: true, setRadioButton: true);
+                if (!success)
                 {
-                    BitmapImage bgImage = new BitmapImage();
-                    bgImage.BeginInit();
-                    bgImage.UriSource = new Uri(dialog.FileName);
-                    bgImage.CacheOption = BitmapCacheOption.OnLoad;
-                    bgImage.EndInit();
-                    bgImage.Freeze();
-
-                    backgroundImageBrush = new ImageBrush(bgImage)
-                    {
-                        Stretch = Stretch.UniformToFill,
-                        TileMode = TileMode.Tile,
-                        Opacity = 0.3
-                    };
-
+                    ApplyDefaultBackgroundImage(updateBackground: true, updateStatus: true);
                     if (rbImageBackground != null)
                         rbImageBackground.IsChecked = true;
-
-                    UpdateBackground();
-
-                    if (statusText != null)
-                        statusText.Text = $"背景图片已设置: {Path.GetFileName(dialog.FileName)}";
-                }
-                catch (Exception ex)
-                {
-                    // 如果加载用户选择的图片失败，尝试加载默认图片
-                    if (statusText != null)
-                        statusText.Text = $"加载背景图片失败，尝试使用默认图片: {ex.Message}";
-
-                    LoadDefaultBackgroundImage();
-
-                    if (rbImageBackground != null)
-                        rbImageBackground.IsChecked = true;
-
-                    UpdateBackground();
                 }
             }
             else
@@ -1088,12 +1044,9 @@ namespace PicViewEx
                 // 用户取消了选择，如果当前没有背景图片，则加载默认图片
                 if (backgroundImageBrush == null)
                 {
-                    LoadDefaultBackgroundImage();
-
+                    ApplyDefaultBackgroundImage(updateBackground: true, updateStatus: true);
                     if (rbImageBackground != null)
                         rbImageBackground.IsChecked = true;
-
-                    UpdateBackground();
                 }
             }
         }
@@ -1257,7 +1210,7 @@ namespace PicViewEx
                 if (statusText != null)
                     statusText.Text = $"加载中: {Path.GetFileName(imagePath)}";
 
-                BitmapImage bitmap = LoadImageWithMagick(imagePath);
+                BitmapImage bitmap = imageLoader.LoadImage(imagePath);
                 if (bitmap != null && mainImage != null)
                 {
                     // 检查是否是GIF文件，如果是则启用动画
@@ -1342,11 +1295,7 @@ namespace PicViewEx
         {
             try
             {
-                var image = new BitmapImage();
-                image.BeginInit();
-                image.UriSource = new Uri(gifPath);
-                image.CacheOption = BitmapCacheOption.OnLoad;
-                image.EndInit();
+                var image = imageLoader.LoadGifAnimationSource(gifPath);
 
                 // 使用WpfAnimatedGif库来播放GIF动画
                 WpfAnimatedGif.ImageBehavior.SetAnimatedSource(mainImage, image);
@@ -1360,48 +1309,14 @@ namespace PicViewEx
                 if (statusText != null)
                     statusText.Text = $"GIF动画加载失败，尝试静态显示: {ex.Message}";
 
-                var bitmap = LoadImageWithMagick(gifPath);
-                if (bitmap != null)
-                {
-                    mainImage.Source = bitmap;
-                }
-            }
-        }
-
-        private BitmapImage LoadImageWithMagick(string imagePath)
-        {
-            try
-            {
-                using (var magickImage = new MagickImage(imagePath))
-                {
-                    magickImage.Format = MagickFormat.Png;
-                    byte[] imageBytes = magickImage.ToByteArray();
-
-                    BitmapImage bitmap = new BitmapImage();
-                    bitmap.BeginInit();
-                    bitmap.StreamSource = new MemoryStream(imageBytes);
-                    bitmap.CacheOption = BitmapCacheOption.OnLoad;
-                    bitmap.EndInit();
-                    bitmap.Freeze();
-
-                    return bitmap;
-                }
-            }
-            catch
-            {
                 try
                 {
-                    BitmapImage bitmap = new BitmapImage();
-                    bitmap.BeginInit();
-                    bitmap.UriSource = new Uri(imagePath);
-                    bitmap.CacheOption = BitmapCacheOption.OnLoad;
-                    bitmap.EndInit();
-                    bitmap.Freeze();
-                    return bitmap;
+                    var bitmap = imageLoader.LoadImage(gifPath);
+                    mainImage.Source = bitmap;
                 }
                 catch
                 {
-                    return null;
+                    // 保持静默，主调用方会处理错误状态
                 }
             }
         }
@@ -1595,7 +1510,7 @@ namespace PicViewEx
                 // 如果没有背景图片，先尝试加载默认图片
                 if (backgroundImageBrush == null)
                 {
-                    LoadDefaultBackgroundImage();
+                    ApplyDefaultBackgroundImage(updateBackground: false, updateStatus: false);
                 }
 
                 // 应用背景图片
@@ -1725,67 +1640,17 @@ namespace PicViewEx
 
                 if (statusText != null)
                     statusText.Text = $"正在生成通道...";
+                var channels = imageLoader.LoadChannels(imagePath);
+                channelCache.AddRange(channels);
+                currentChannelCachePath = imagePath;
 
-                using (var magickImage = new MagickImage(imagePath))
+                foreach (var (name, channelImage) in channels)
                 {
-                    // 先计算需要生成的通道数量
-                    int expectedChannels = 3; // RGB基础通道
-                    if (magickImage.HasAlpha)
-                        expectedChannels++; // 加上Alpha通道
-
-                    // 生成并缓存所有通道
-                    var channels = new List<(string name, MagickImage image)>();
-
-                    // 准备RGB通道
-                    var redImage = new MagickImage(magickImage);
-                    redImage.Evaluate(Channels.Green, EvaluateOperator.Set, 0);
-                    redImage.Evaluate(Channels.Blue, EvaluateOperator.Set, 0);
-                    channels.Add(("红色 (R)", redImage));
-
-                    var greenImage = new MagickImage(magickImage);
-                    greenImage.Evaluate(Channels.Red, EvaluateOperator.Set, 0);
-                    greenImage.Evaluate(Channels.Blue, EvaluateOperator.Set, 0);
-                    channels.Add(("绿色 (G)", greenImage));
-
-                    var blueImage = new MagickImage(magickImage);
-                    blueImage.Evaluate(Channels.Red, EvaluateOperator.Set, 0);
-                    blueImage.Evaluate(Channels.Green, EvaluateOperator.Set, 0);
-                    channels.Add(("蓝色 (B)", blueImage));
-
-                    // 如果有Alpha通道，添加到列表
-                    if (magickImage.HasAlpha)
-                    {
-                        var alphaImage = new MagickImage(magickImage);
-                        alphaImage.Alpha(AlphaOption.Extract);
-                        alphaImage.Format = MagickFormat.Png;
-                        channels.Add(("透明 (Alpha)", alphaImage));
-                    }
-
-                    // 转换所有通道为BitmapImage并添加到缓存
-                    foreach (var (name, channelImage) in channels)
-                    {
-                        var bitmap = CreateBitmapFromMagickImage(channelImage);
-                        if (bitmap != null)
-                        {
-                            channelCache.Add(Tuple.Create(name, bitmap));
-
-                            CreateChannelControl(name, bitmap);
-                        }
-                        channelImage.Dispose();
-                    }
-
-                    // 验证是否所有通道都已生成
-                    if (channelCache.Count == expectedChannels)
-                    {
-                        currentChannelCachePath = imagePath;
-                        if (statusText != null)
-                            statusText.Text = $"通道加载完成 ({channelCache.Count}个) - {Path.GetFileName(imagePath)}";
-                    }
-                    else
-                    {
-                        throw new Exception($"通道生成不完整，预期{expectedChannels}个通道，实际生成{channelCache.Count}个");
-                    }
+                    CreateChannelControl(name, channelImage);
                 }
+
+                if (statusText != null)
+                    statusText.Text = $"通道加载完成 ({channelCache.Count}个) - {Path.GetFileName(imagePath)}";
             }
             catch (Exception ex)
             {
@@ -1794,92 +1659,6 @@ namespace PicViewEx
                 currentChannelCachePath = null;
                 if (statusText != null)
                     statusText.Text = $"通道加载失败: {ex.Message}";
-            }
-        }
-
-        private void CreateSimpleRGBChannels(MagickImage originalImage)
-        {
-            try
-            {
-                // R通道 - 保留红色，其他为0
-                var redImage = new MagickImage(originalImage);
-                redImage.Evaluate(Channels.Green, EvaluateOperator.Set, 0);
-                redImage.Evaluate(Channels.Blue, EvaluateOperator.Set, 0);
-                var redBitmap = CreateBitmapFromMagickImage(redImage);
-                if (redBitmap != null)
-                {
-                    channelCache.Add(Tuple.Create("红色 (R)", redBitmap));
-
-                    CreateChannelControl("红色 (R)", redBitmap);
-                }
-                redImage.Dispose();
-
-                // G通道 - 保留绿色，其他为0
-                var greenImage = new MagickImage(originalImage);
-                greenImage.Evaluate(Channels.Red, EvaluateOperator.Set, 0);
-                greenImage.Evaluate(Channels.Blue, EvaluateOperator.Set, 0);
-                var greenBitmap = CreateBitmapFromMagickImage(greenImage);
-                if (greenBitmap != null)
-                    CreateChannelControl("绿色 (G)", greenBitmap);
-                greenImage.Dispose();
-
-                // B通道 - 保留蓝色，其他为0
-                var blueImage = new MagickImage(originalImage);
-                blueImage.Evaluate(Channels.Red, EvaluateOperator.Set, 0);
-                blueImage.Evaluate(Channels.Green, EvaluateOperator.Set, 0);
-                var blueBitmap = CreateBitmapFromMagickImage(blueImage);
-                if (blueBitmap != null)
-                    CreateChannelControl("蓝色 (B)", blueBitmap);
-                blueImage.Dispose();
-            }
-            catch (Exception ex)
-            {
-                if (statusText != null)
-                    statusText.Text = $"RGB通道分离失败: {ex.Message}";
-            }
-        }
-
-        private void CreateAlphaChannel(MagickImage originalImage)
-        {
-            try
-            {
-                // 提取Alpha通道
-                var alphaImage = new MagickImage(originalImage);
-                alphaImage.Alpha(AlphaOption.Extract);
-                alphaImage.Format = MagickFormat.Png;
-
-                var alphaBitmap = CreateBitmapFromMagickImage(alphaImage);
-                if (alphaBitmap != null)
-                    CreateChannelControl("透明 (Alpha)", alphaBitmap);
-
-                alphaImage.Dispose();
-            }
-            catch (Exception ex)
-            {
-                if (statusText != null)
-                    statusText.Text = $"Alpha通道提取失败: {ex.Message}";
-            }
-        }
-
-        private BitmapImage CreateBitmapFromMagickImage(MagickImage magickImage)
-        {
-            try
-            {
-                magickImage.Format = MagickFormat.Png;
-                byte[] imageBytes = magickImage.ToByteArray();
-
-                BitmapImage bitmap = new BitmapImage();
-                bitmap.BeginInit();
-                bitmap.StreamSource = new MemoryStream(imageBytes);
-                bitmap.CacheOption = BitmapCacheOption.OnLoad;
-                bitmap.EndInit();
-                bitmap.Freeze(); // 确保位图被冻结，这样可以在不同线程间安全使用
-
-                return bitmap;
-            }
-            catch
-            {
-                return null;
             }
         }
 
@@ -2788,7 +2567,7 @@ namespace PicViewEx
                 // 第一步：恢复背景图片路径（如果有的话）
                 if (!string.IsNullOrEmpty(appSettings.BackgroundImagePath) && File.Exists(appSettings.BackgroundImagePath))
                 {
-                    LoadBackgroundImageFromPath(appSettings.BackgroundImagePath);
+                    ApplyBackgroundImageFromPath(appSettings.BackgroundImagePath, updateStatus: false, updateBackground: false);
                 }
 
                 // 第二步：恢复颜色值（禁用事件处理器以防止自动切换背景类型）
@@ -3016,7 +2795,7 @@ namespace PicViewEx
                     if (rbImageBackground != null) rbImageBackground.IsChecked = true;
                     if (!string.IsNullOrEmpty(appSettings.BackgroundImagePath) && File.Exists(appSettings.BackgroundImagePath))
                     {
-                        LoadBackgroundImageFromPath(appSettings.BackgroundImagePath);
+                        ApplyBackgroundImageFromPath(appSettings.BackgroundImagePath, updateStatus: false, updateBackground: false);
                     }
                     break;
                 case "WindowTransparent":
@@ -3113,34 +2892,6 @@ namespace PicViewEx
             {
                 imagePosition.X = appSettings.LastImageX;
                 imagePosition.Y = appSettings.LastImageY;
-            }
-        }
-
-        private void LoadBackgroundImageFromPath(string imagePath)
-        {
-            try
-            {
-                if (File.Exists(imagePath))
-                {
-                    BitmapImage bgImage = new BitmapImage();
-                    bgImage.BeginInit();
-                    bgImage.UriSource = new Uri(imagePath);
-                    bgImage.CacheOption = BitmapCacheOption.OnLoad;
-                    bgImage.EndInit();
-                    bgImage.Freeze();
-
-                    backgroundImageBrush = new ImageBrush(bgImage)
-                    {
-                        Stretch = Stretch.UniformToFill,
-                        TileMode = TileMode.Tile,
-                        Opacity = 0.3
-                    };
-                }
-            }
-            catch (Exception ex)
-            {
-                if (statusText != null)
-                    statusText.Text = $"加载背景图片失败: {ex.Message}";
             }
         }
 
@@ -4114,7 +3865,7 @@ namespace PicViewEx
                         if (supportedFormats.Contains(extension))
                         {
                             // 找到第一个支持的图片文件
-                            clipboardImage = LoadImageWithMagick(file);
+                            clipboardImage = imageLoader.LoadImage(file);
                             sourceInfo = $"剪贴板文件: {Path.GetFileName(file)}";
                             break;
                         }
@@ -4289,48 +4040,21 @@ namespace PicViewEx
 
                 if (statusText != null)
                     statusText.Text = "正在为剪贴板图片生成通道...";
+                var channels = imageLoader.LoadChannels(image);
 
-                // 将 BitmapSource 转换为字节数组，然后用 ImageMagick 处理
-                byte[] imageBytes = ConvertBitmapSourceToBytes(image);
-
-                using (var magickImage = new MagickImage(imageBytes))
+                foreach (var (name, channelImage) in channels)
                 {
-                    // 生成RGB通道
-                    CreateSimpleRGBChannels(magickImage);
-
-                    // 如果有Alpha通道，也生成Alpha通道
-                    if (magickImage.HasAlpha)
-                    {
-                        CreateAlphaChannel(magickImage);
-                    }
-
-                    if (statusText != null)
-                        statusText.Text = $"剪贴板图片通道加载完成 ({channelStackPanel.Children.Count}个)";
+                    CreateChannelControl(name, channelImage);
                 }
+
+                if (statusText != null)
+                    statusText.Text = $"剪贴板图片通道加载完成 ({channelStackPanel.Children.Count}个)";
             }
             catch (Exception ex)
             {
                 if (statusText != null)
                     statusText.Text = $"剪贴板图片通道生成失败: {ex.Message}";
             }
-        }
-
-        /// <summary>
-        /// 将 BitmapSource 转换为字节数组
-        /// </summary>
-        private byte[] ConvertBitmapSourceToBytes(BitmapSource bitmapSource)
-        {
-            byte[] data;
-            var encoder = new PngBitmapEncoder();
-            encoder.Frames.Add(BitmapFrame.Create(bitmapSource));
-
-            using (var ms = new MemoryStream())
-            {
-                encoder.Save(ms);
-                data = ms.ToArray();
-            }
-
-            return data;
         }
 
         /// <summary>

--- a/PicViewEx/PicViewEx.csproj
+++ b/PicViewEx/PicViewEx.csproj
@@ -75,6 +75,7 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="EverythingSearch.cs" />
+    <Compile Include="ImageLoader.cs" />
     <Compile Include="OpenWithManagerWindow.xaml.cs">
       <DependentUpon>OpenWithManagerWindow.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
## Summary
- introduce an ImageLoader class to centralize bitmap, background, and channel loading logic
- update MainWindow to rely on the new loader for image, GIF, channel, and background operations and reuse helper methods
- register the new class in the project file

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e37088319c832fa192ede7c6dcb2a4